### PR TITLE
HTML output method

### DIFF
--- a/SHFB/Source/BuildAssembler/BuildComponents/SaveComponent.cs
+++ b/SHFB/Source/BuildAssembler/BuildComponents/SaveComponent.cs
@@ -13,6 +13,7 @@ using System;
 using System.Configuration;
 using System.Globalization;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Xml;
 using System.Xml.XPath;
@@ -82,6 +83,40 @@ namespace Microsoft.Ddue.Tools
             if(saveNode == null)
                 throw new ConfigurationErrorsException("When instantiating a save component, you must specify " +
                     "a the target file using the <save> element.");
+
+            string outputMethodValue = saveNode.GetAttribute("method", String.Empty);
+            XmlOutputMethod? outputMethod = null;
+            switch (outputMethodValue)
+            {
+            case "html":
+                outputMethod = XmlOutputMethod.Html;
+                break;
+
+            case "xml":
+                outputMethod = XmlOutputMethod.Xml;
+                break;
+
+            case "text":
+                outputMethod = XmlOutputMethod.Text;
+                break;
+
+            case "auto":
+                outputMethod = XmlOutputMethod.AutoDetect;
+                break;
+
+            case null:
+                break;
+
+            default:
+                throw new ConfigurationErrorsException("The specified output method is not valid for the " +
+                    "save component.");
+            }
+
+            if (outputMethod != null)
+            {
+                var propertyInfo = typeof(XmlWriterSettings).GetProperty("OutputMethod", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                propertyInfo.SetValue(settings, outputMethod.Value, null);
+            }
 
             string baseValue = saveNode.GetAttribute("base", String.Empty);
 

--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/SHFBConceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/SHFBConceptual.config
@@ -155,7 +155,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 
@@ -203,7 +203,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 
@@ -254,7 +254,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="false" add-xhtml-namespace="true" />
+								omit-xml-declaration="false" add-xhtml-namespace="true" method="html" />
 						</component>
 					</helpOutput>
 
@@ -297,7 +297,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/SHFBReference.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/SHFBReference.config
@@ -285,7 +285,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 
@@ -328,7 +328,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 
@@ -374,7 +374,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true" />
+								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true" method="html" />
 						</component>
 					</helpOutput>
 
@@ -412,7 +412,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/conceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/conceptual.config
@@ -175,7 +175,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base=".\Output\html" path="concat($key,'.htm')" link="../html" indent="true"
-						omit-xml-declaration="true" />
+						omit-xml-declaration="true" method="html" />
 				</component>
 
 				<!-- Record file creation events -->

--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/sandcastle-mshc.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/sandcastle-mshc.config
@@ -202,7 +202,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="true"
-						omit-xml-declaration="false" add-xhtml-namespace="true" />
+						omit-xml-declaration="false" add-xhtml-namespace="true" method="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/sandcastle.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/sandcastle.config
@@ -195,7 +195,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="true"
-						omit-xml-declaration="true" />
+						omit-xml-declaration="true" method="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/SHFBConceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/SHFBConceptual.config
@@ -163,7 +163,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 
@@ -219,7 +219,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 
@@ -278,7 +278,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="false" add-xhtml-namespace="true" />
+								omit-xml-declaration="false" add-xhtml-namespace="true" method="html" />
 						</component>
 					</helpOutput>
 
@@ -329,7 +329,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/SHFBReference.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/SHFBReference.config
@@ -289,7 +289,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 
@@ -340,7 +340,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" method="html" />
 						</component>
 					</helpOutput>
 
@@ -394,7 +394,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true"/>
+								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true" method="html"/>
 						</component>
 					</helpOutput>
 
@@ -440,7 +440,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false"/>
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" method="html"/>
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/conceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/conceptual.config
@@ -146,7 +146,7 @@
 
 				<!-- Save the result -->
 				<component id="Save Component">
-					<save base=".\Output\html" path="concat($key,'.htm')" indent="false" omit-xml-declaration="true" />
+					<save base=".\Output\html" path="concat($key,'.htm')" indent="false" omit-xml-declaration="true" method="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/sandcastle-mshc.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/sandcastle-mshc.config
@@ -209,7 +209,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="false"
-						omit-xml-declaration="false" add-xhtml-namespace="true" />
+						omit-xml-declaration="false" add-xhtml-namespace="true" method="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/sandcastle.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/sandcastle.config
@@ -200,7 +200,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="false"
-						omit-xml-declaration="true" />
+						omit-xml-declaration="true" method="html" />
 				</component>
 
 			</components>


### PR DESCRIPTION
- Update Save Component to allow setting the XML output method
- Update the VS2005 and VS2010 styles to use the "html" output method
